### PR TITLE
[BUGFIX] Fix backend module registration

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -21,6 +21,10 @@ $GLOBALS['TBE_MODULES']['_configuration']['rightsandroles'] = [
     'iconIdentifier' => 'module-rightsandroles'
 ];
 
+if (empty($_EXTKEY)) {
+    $_EXTKEY = 'rights_and_roles';
+}
+
 /**
  * Module Rights and Roles > Matrix
  */


### PR DESCRIPTION
This patch defines the empty variable $_EXTKEY.
This way the module registration works again and is compatible with v9 and v10